### PR TITLE
Move interrupt data out of spiram

### DIFF
--- a/SpinDance_Fork_Changes.md
+++ b/SpinDance_Fork_Changes.md
@@ -41,6 +41,11 @@ components/wifi_provisioning/src/wifi_config.c
 components/wifi_provisioning/src/wifi_provisioning_priv.h
 components/wifi_provisioning/src/wifi_scan.c
 tools/idf_tools.py
+components/bt/controller/esp32/bt.c
+components/bt/controller/esp32s3/bt.c
+components/esp_wifi/esp32/esp_adapter.c
+components/esp_wifi/esp32s2/esp_adapter.c
+components/esp_wifi/esp32s3/esp_adapter.c
 ```
 
 ## Feature List
@@ -173,3 +178,13 @@ The features, their associated changes to ESP IDF and how the change is related 
 |components/wifi_provisioning/src/wifi_provisioning_priv.h             | WPA2 Enterprise NW Support |
 |components/wifi_provisioning/src/wifi_scan.c                          | JWT Authorization for Protocomm WiFi Provisioning |
 |tools/idf_tools.py                                                    | Python Version Change |
+
+## Git Patch
+A git patch was applied that moves FREERTOS static data out of spiram. The patch prevents a cache memory panic
+during bluetooth interrupts and was applied to the following files:
+
+- components/bt/controller/esp32/bt.c
+- components/bt/controller/esp32s3/bt.c
+- components/esp_wifi/esp32/esp_adapter.c
+- components/esp_wifi/esp32s2/esp_adapter.c
+- components/esp_wifi/esp32s3/esp_adapter.c

--- a/components/bt/controller/esp32/bt.c
+++ b/components/bt/controller/esp32/bt.c
@@ -509,9 +509,8 @@ static inline void btdm_check_and_init_bb(void)
 #if CONFIG_SPIRAM_USE_MALLOC
 static bool btdm_queue_generic_register(const btdm_queue_item_t *queue)
 {
-    if (!btdm_queue_table_mux || !queue) {
-        return NULL;
-    }
+    assert(btdm_queue_table_mux != NULL);
+    assert(queue != NULL);
 
     bool ret = false;
     btdm_queue_item_t *item;
@@ -525,14 +524,14 @@ static bool btdm_queue_generic_register(const btdm_queue_item_t *queue)
         }
     }
     xSemaphoreGive(btdm_queue_table_mux);
+    assert(ret);
     return ret;
 }
 
 static bool btdm_queue_generic_deregister(btdm_queue_item_t *queue)
 {
-    if (!btdm_queue_table_mux || !queue) {
-        return false;
-    }
+    assert(btdm_queue_table_mux != NULL);
+    assert(queue != NULL);
 
     bool ret = false;
     btdm_queue_item_t *item;
@@ -809,8 +808,8 @@ static void mutex_delete_wrapper(void *mutex)
         free(item.buffer);
     }
 
-    return;
 #endif
+    return;
 }
 
 static int32_t mutex_lock_wrapper(void *mutex)
@@ -890,9 +889,9 @@ static void queue_delete_wrapper(void *queue)
         free(item.storage);
         free(item.buffer);
     }
+#endif
 
     return;
-#endif
 }
 
 #if CONFIG_BTDM_CTRL_HLI

--- a/components/bt/controller/esp32/bt.c
+++ b/components/bt/controller/esp32/bt.c
@@ -807,7 +807,6 @@ static void mutex_delete_wrapper(void *mutex)
         vSemaphoreDelete(item.handle);
         free(item.buffer);
     }
-
 #endif
     return;
 }
@@ -890,7 +889,6 @@ static void queue_delete_wrapper(void *queue)
         free(item.buffer);
     }
 #endif
-
     return;
 }
 

--- a/components/bt/controller/esp32/bt.c
+++ b/components/bt/controller/esp32/bt.c
@@ -459,7 +459,6 @@ static DRAM_ATTR SemaphoreHandle_t btdm_queue_table_mux = NULL;
 // timestamp when PHY/RF was switched on
 static DRAM_ATTR int64_t s_time_phy_rf_just_enabled = 0;
 static DRAM_ATTR esp_bt_controller_status_t btdm_controller_status = ESP_BT_CONTROLLER_STATUS_IDLE;
-
 static DRAM_ATTR portMUX_TYPE global_int_mux = portMUX_INITIALIZER_UNLOCKED;
 
 // measured average low power clock period in micro seconds

--- a/components/bt/controller/esp32s3/bt.c
+++ b/components/bt/controller/esp32s3/bt.c
@@ -773,7 +773,6 @@ static void queue_delete_wrapper(void *queue)
         free(item.buffer);
     }
 #endif
-
     return;
 }
 

--- a/components/bt/controller/esp32s3/bt.c
+++ b/components/bt/controller/esp32s3/bt.c
@@ -105,6 +105,11 @@ do{\
 #define OSI_VERSION              0x00010006
 #define OSI_MAGIC_VALUE          0xFADEBEAD
 
+/* SPIRAM Configuration */
+#if CONFIG_SPIRAM_USE_MALLOC
+#define BTDM_MAX_QUEUE_NUM       (5)
+#endif
+
 /* Types definition
  ************************************************************************
  */
@@ -129,6 +134,15 @@ typedef struct {
     intptr_t start;
     intptr_t end;
 } btdm_dram_available_region_t;
+
+/* PSRAM configuration */
+#if CONFIG_SPIRAM_USE_MALLOC
+typedef struct {
+    QueueHandle_t handle;
+    void *storage;
+    void *buffer;
+} btdm_queue_item_t;
+#endif
 
 typedef void (* osi_intr_handler)(void);
 
@@ -268,6 +282,11 @@ extern char _bt_tmp_bss_end;
 /* Local Function Declare
  *********************************************************************
  */
+#if CONFIG_SPIRAM_USE_MALLOC
+static bool btdm_queue_generic_register(const btdm_queue_item_t *queue);
+static bool btdm_queue_generic_deregister(btdm_queue_item_t *queue);
+#endif /* CONFIG_SPIRAM_USE_MALLOC */
+
 static void interrupt_set_wrapper(int32_t cpu_no, int32_t intr_source, int32_t intr_num, int32_t intr_prio);
 static void interrupt_clear_wrapper(int32_t intr_source, int32_t intr_num);
 static void interrupt_handler_set_wrapper(int n, void *fn, void *arg);
@@ -374,6 +393,11 @@ static const struct osi_funcs_t osi_funcs_ro = {
 
 static DRAM_ATTR struct osi_funcs_t *osi_funcs_p;
 
+#if CONFIG_SPIRAM_USE_MALLOC
+static DRAM_ATTR btdm_queue_item_t btdm_queue_table[BTDM_MAX_QUEUE_NUM];
+static DRAM_ATTR SemaphoreHandle_t btdm_queue_table_mux = NULL;
+#endif /* #if CONFIG_SPIRAM_USE_MALLOC */
+
 /* Static variable declare */
 static DRAM_ATTR esp_bt_controller_status_t btdm_controller_status = ESP_BT_CONTROLLER_STATUS_IDLE;
 
@@ -431,6 +455,51 @@ static inline void esp_bt_power_domain_off(void)
     esp_wifi_bt_power_domain_off();
 }
 
+#if CONFIG_SPIRAM_USE_MALLOC
+static bool btdm_queue_generic_register(const btdm_queue_item_t *queue)
+{
+    assert(btdm_queue_table_mux != NULL);
+    assert(queue != NULL);
+
+    bool ret = false;
+    btdm_queue_item_t *item;
+    xSemaphoreTake(btdm_queue_table_mux, portMAX_DELAY);
+    for (int i = 0; i < BTDM_MAX_QUEUE_NUM; ++i) {
+        item = &btdm_queue_table[i];
+        if (item->handle == NULL) {
+            memcpy(item, queue, sizeof(btdm_queue_item_t));
+            ret = true;
+            break;
+        }
+    }
+    xSemaphoreGive(btdm_queue_table_mux);
+    assert(ret);
+    return ret;
+}
+
+static bool btdm_queue_generic_deregister(btdm_queue_item_t *queue)
+{
+    assert(btdm_queue_table_mux != NULL);
+    assert(queue != NULL);
+
+    bool ret = false;
+    btdm_queue_item_t *item;
+    xSemaphoreTake(btdm_queue_table_mux, portMAX_DELAY);
+    for (int i = 0; i < BTDM_MAX_QUEUE_NUM; ++i) {
+        item = &btdm_queue_table[i];
+        if (item->handle == queue->handle) {
+            memcpy(queue, item, sizeof(btdm_queue_item_t));
+            memset(item, 0, sizeof(btdm_queue_item_t));
+            ret = true;
+            break;
+        }
+    }
+    xSemaphoreGive(btdm_queue_table_mux);
+    return ret;
+}
+
+#endif /* CONFIG_SPIRAM_USE_MALLOC */
+
 static void interrupt_set_wrapper(int32_t cpu_no, int32_t intr_source, int32_t intr_num, int32_t intr_prio)
 {
     intr_matrix_set(cpu_no, intr_source, intr_num);
@@ -480,12 +549,66 @@ static void IRAM_ATTR task_yield_from_isr(void)
 
 static void *semphr_create_wrapper(uint32_t max, uint32_t init)
 {
-    return (void *)xSemaphoreCreateCounting(max, init);
+    void *handle = NULL;
+
+#if !CONFIG_SPIRAM_USE_MALLOC
+    handle = (void *)xSemaphoreCreateCounting(max, init);
+#else
+    StaticQueue_t *queue_buffer = NULL;
+
+    queue_buffer = heap_caps_malloc(sizeof(StaticQueue_t), MALLOC_CAP_INTERNAL|MALLOC_CAP_8BIT);
+    if (!queue_buffer) {
+        goto error;
+    }
+
+    handle = (void *)xSemaphoreCreateCountingStatic(max, init, queue_buffer);
+    if (!handle) {
+        goto error;
+    }
+
+    btdm_queue_item_t item = {
+        .handle = handle,
+        .storage = NULL,
+        .buffer = queue_buffer,
+    };
+
+    if (!btdm_queue_generic_register(&item)) {
+        goto error;
+    }
+#endif
+
+    return handle;
+
+#if CONFIG_SPIRAM_USE_MALLOC
+ error:
+    if (handle) {
+        vSemaphoreDelete(handle);
+    }
+    if (queue_buffer) {
+        free(queue_buffer);
+    }
+
+    return NULL;
+#endif
+
 }
 
 static void semphr_delete_wrapper(void *semphr)
 {
+#if !CONFIG_SPIRAM_USE_MALLOC
     vSemaphoreDelete(semphr);
+#else
+    btdm_queue_item_t item = {
+        .handle = semphr,
+        .storage = NULL,
+        .buffer = NULL,
+    };
+
+    if (btdm_queue_generic_deregister(&item)) {
+        vSemaphoreDelete(item.handle);
+        free(item.buffer);
+    }
+#endif
 }
 
 static int IRAM_ATTR semphr_take_from_isr_wrapper(void *semphr, void *hptw)
@@ -514,12 +637,63 @@ static int semphr_give_wrapper(void *semphr)
 
 static void *mutex_create_wrapper(void)
 {
+#if CONFIG_SPIRAM_USE_MALLOC
+    StaticQueue_t *queue_buffer = NULL;
+    QueueHandle_t handle = NULL;
+
+    queue_buffer = heap_caps_malloc(sizeof(StaticQueue_t), MALLOC_CAP_INTERNAL|MALLOC_CAP_8BIT);
+    if (!queue_buffer) {
+        goto error;
+    }
+
+    handle = xSemaphoreCreateMutexStatic(queue_buffer);
+    if (!handle) {
+        goto error;
+    }
+
+    btdm_queue_item_t item = {
+        .handle = handle,
+        .storage = NULL,
+        .buffer = queue_buffer,
+    };
+
+    if (!btdm_queue_generic_register(&item)) {
+        goto error;
+    }
+    return handle;
+
+ error:
+    if (handle) {
+        vSemaphoreDelete(handle);
+    }
+    if (queue_buffer) {
+        free(queue_buffer);
+    }
+
+    return NULL;
+#else
     return (void *)xSemaphoreCreateMutex();
+#endif
 }
 
 static void mutex_delete_wrapper(void *mutex)
 {
+#if !CONFIG_SPIRAM_USE_MALLOC
     vSemaphoreDelete(mutex);
+#else
+    btdm_queue_item_t item = {
+        .handle = mutex,
+        .storage = NULL,
+        .buffer = NULL,
+    };
+
+    if (btdm_queue_generic_deregister(&item)) {
+        vSemaphoreDelete(item.handle);
+        free(item.buffer);
+    }
+
+#endif
+    return;
 }
 
 static int mutex_lock_wrapper(void *mutex)
@@ -534,12 +708,74 @@ static int mutex_unlock_wrapper(void *mutex)
 
 static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size)
 {
+#if CONFIG_SPIRAM_USE_MALLOC
+    StaticQueue_t *queue_buffer = NULL;
+    uint8_t *queue_storage = NULL;
+    QueueHandle_t handle = NULL;
+
+    queue_buffer = heap_caps_malloc(sizeof(StaticQueue_t), MALLOC_CAP_INTERNAL|MALLOC_CAP_8BIT);
+    if (!queue_buffer) {
+        goto error;
+    }
+
+    queue_storage = heap_caps_malloc((queue_len*item_size), MALLOC_CAP_INTERNAL|MALLOC_CAP_8BIT);
+    if (!queue_storage ) {
+        goto error;
+    }
+
+    handle = xQueueCreateStatic(queue_len, item_size, queue_storage, queue_buffer);
+    if (!handle) {
+        goto error;
+    }
+
+    btdm_queue_item_t item = {
+        .handle = handle,
+        .storage = queue_storage,
+        .buffer = queue_buffer,
+    };
+
+    if (!btdm_queue_generic_register(&item)) {
+        goto error;
+    }
+
+    return handle;
+
+ error:
+    if (handle) {
+        vQueueDelete(handle);
+    }
+    if (queue_storage) {
+        free(queue_storage);
+    }
+    if (queue_buffer) {
+        free(queue_buffer);
+    }
+
+    return NULL;
+#else
     return (void *)xQueueCreate(queue_len, item_size);
+#endif
 }
 
 static void queue_delete_wrapper(void *queue)
 {
+#if !CONFIG_SPIRAM_USE_MALLOC
     vQueueDelete(queue);
+#else
+    btdm_queue_item_t item = {
+        .handle = queue,
+        .storage = NULL,
+        .buffer = NULL,
+    };
+
+    if (btdm_queue_generic_deregister(&item)) {
+        vQueueDelete(item.handle);
+        free(item.storage);
+        free(item.buffer);
+    }
+#endif
+
+    return;
 }
 
 static int queue_send_wrapper(void *queue, void *item, uint32_t block_time_ms)
@@ -964,6 +1200,14 @@ esp_err_t esp_bt_controller_init(esp_bt_controller_config_t *cfg)
 
     ESP_LOGI(BT_LOG_TAG, "BT controller compile version [%s]", btdm_controller_get_compile_version());
 
+#if CONFIG_SPIRAM_USE_MALLOC
+    btdm_queue_table_mux = xSemaphoreCreateMutex();
+    if (btdm_queue_table_mux == NULL) {
+        return ESP_ERR_NO_MEM;
+    }
+    memset(btdm_queue_table, 0, sizeof(btdm_queue_item_t) * BTDM_MAX_QUEUE_NUM);
+#endif
+
     // init low-power control resources
     do {
         // set default values for global states or resources
@@ -1202,6 +1446,12 @@ esp_err_t esp_bt_controller_deinit(void)
             s_wakeup_req_sem = NULL;
         }
     } while (0);
+
+#if CONFIG_SPIRAM_USE_MALLOC
+    vSemaphoreDelete(btdm_queue_table_mux);
+    btdm_queue_table_mux = NULL;
+    memset(btdm_queue_table, 0, sizeof(btdm_queue_item_t) * BTDM_MAX_QUEUE_NUM);
+#endif
 
 #if CONFIG_MAC_BB_PD
     esp_unregister_mac_bb_pd_callback(btdm_mac_bb_power_down_cb);

--- a/components/bt/controller/esp32s3/bt.c
+++ b/components/bt/controller/esp32s3/bt.c
@@ -590,7 +590,6 @@ static void *semphr_create_wrapper(uint32_t max, uint32_t init)
 
     return NULL;
 #endif
-
 }
 
 static void semphr_delete_wrapper(void *semphr)

--- a/components/esp_wifi/esp32/esp_adapter.c
+++ b/components/esp_wifi/esp32/esp_adapter.c
@@ -365,7 +365,6 @@ static void coex_semphr_delete_wrapper(void *semphr)
 #endif
 }
 
-
 static void wifi_thread_semphr_free(void* data)
 {
     SemaphoreHandle_t *sem = (SemaphoreHandle_t*)(data);

--- a/components/esp_wifi/esp32/esp_adapter.c
+++ b/components/esp_wifi/esp32/esp_adapter.c
@@ -53,6 +53,57 @@
 
 #define TAG "esp_adapter"
 
+#if CONFIG_SPIRAM_USE_MALLOC
+/* SPIRAM Configuration */
+#define COEX_MAX_QUEUE_NUM       (2)
+
+
+/* PSRAM configuration */
+typedef struct {
+    QueueHandle_t handle;
+    void *storage;
+    void *buffer;
+} coex_queue_item_t;
+
+static DRAM_ATTR coex_queue_item_t coex_queue_table[COEX_MAX_QUEUE_NUM];
+
+static bool coex_queue_generic_register(const coex_queue_item_t *queue)
+{
+    // Coexist model will only create sempher twice in coex_pre_init when CPU start,
+    // And will never delete.
+    // So we do not need use mutex to protect it.
+
+    bool ret = false;
+    coex_queue_item_t *item;
+    for (int i = 0; i < COEX_MAX_QUEUE_NUM; ++i) {
+        item = &coex_queue_table[i];
+        if (item->handle == NULL) {
+            memcpy(item, queue, sizeof(coex_queue_item_t));
+            ret = true;
+            break;
+        }
+    }
+    assert(ret);
+    return ret;
+}
+
+static bool coex_queue_generic_deregister(coex_queue_item_t *queue)
+{
+    bool ret = false;
+    coex_queue_item_t *item;
+    for (int i = 0; i < COEX_MAX_QUEUE_NUM; ++i) {
+        item = &coex_queue_table[i];
+        if (item->handle == queue->handle) {
+            memcpy(queue, item, sizeof(coex_queue_item_t));
+            memset(item, 0, sizeof(coex_queue_item_t));
+            ret = true;
+            break;
+        }
+    }
+    return ret;
+}
+#endif
+
 #ifdef CONFIG_PM_ENABLE
 extern void wifi_apb80m_request(void);
 extern void wifi_apb80m_release(void);
@@ -253,6 +304,71 @@ static void semphr_delete_wrapper(void *semphr)
 {
     vSemaphoreDelete(semphr);
 }
+
+static void *coex_semphr_create_wrapper(uint32_t max, uint32_t init)
+{
+    void *handle = NULL;
+
+#if !CONFIG_SPIRAM_USE_MALLOC
+    handle = (void *)xSemaphoreCreateCounting(max, init);
+#else
+    StaticQueue_t *queue_buffer = NULL;
+
+    queue_buffer = heap_caps_malloc(sizeof(StaticQueue_t), MALLOC_CAP_INTERNAL|MALLOC_CAP_8BIT);
+    if (!queue_buffer) {
+        goto error;
+    }
+
+    handle = (void *)xSemaphoreCreateCountingStatic(max, init, queue_buffer);
+    if (!handle) {
+        goto error;
+    }
+
+    coex_queue_item_t item = {
+        .handle = handle,
+        .storage = NULL,
+        .buffer = queue_buffer,
+    };
+
+    if (!coex_queue_generic_register(&item)) {
+        goto error;
+    }
+#endif
+
+    return handle;
+
+#if CONFIG_SPIRAM_USE_MALLOC
+ error:
+    if (handle) {
+        vSemaphoreDelete(handle);
+    }
+    if (queue_buffer) {
+        free(queue_buffer);
+    }
+
+    return NULL;
+#endif
+
+}
+
+static void coex_semphr_delete_wrapper(void *semphr)
+{
+#if !CONFIG_SPIRAM_USE_MALLOC
+    vSemaphoreDelete(semphr);
+#else
+    coex_queue_item_t item = {
+        .handle = semphr,
+        .storage = NULL,
+        .buffer = NULL,
+    };
+
+    if (coex_queue_generic_deregister(&item)) {
+        vSemaphoreDelete(item.handle);
+        free(item.buffer);
+    }
+#endif
+}
+
 
 static void wifi_thread_semphr_free(void* data)
 {
@@ -789,8 +905,8 @@ coex_adapter_funcs_t g_coex_adapter_funcs = {
     ._int_disable = wifi_int_disable_wrapper,
     ._int_enable = wifi_int_restore_wrapper,
     ._task_yield_from_isr = task_yield_from_isr_wrapper,
-    ._semphr_create = semphr_create_wrapper,
-    ._semphr_delete = semphr_delete_wrapper,
+    ._semphr_create = coex_semphr_create_wrapper,
+    ._semphr_delete = coex_semphr_delete_wrapper,
     ._semphr_take_from_isr = semphr_take_from_isr_wrapper,
     ._semphr_give_from_isr = semphr_give_from_isr_wrapper,
     ._semphr_take = semphr_take_wrapper,

--- a/components/esp_wifi/esp32/esp_adapter.c
+++ b/components/esp_wifi/esp32/esp_adapter.c
@@ -57,7 +57,6 @@
 /* SPIRAM Configuration */
 #define COEX_MAX_QUEUE_NUM       (2)
 
-
 /* PSRAM configuration */
 typedef struct {
     QueueHandle_t handle;
@@ -69,7 +68,7 @@ static DRAM_ATTR coex_queue_item_t coex_queue_table[COEX_MAX_QUEUE_NUM];
 
 static bool coex_queue_generic_register(const coex_queue_item_t *queue)
 {
-    // Coexist model will only create sempher twice in coex_pre_init when CPU start,
+    // Coexist model will only create semaphore twice in coex_pre_init when CPU start,
     // And will never delete.
     // So we do not need use mutex to protect it.
 
@@ -214,7 +213,6 @@ void wifi_delete_queue(wifi_static_queue_t *queue)
             free(queue->storage);
         }
 #endif
-
         free(queue);
     }
 }
@@ -334,7 +332,6 @@ static void *coex_semphr_create_wrapper(uint32_t max, uint32_t init)
         goto error;
     }
 #endif
-
     return handle;
 
 #if CONFIG_SPIRAM_USE_MALLOC
@@ -348,7 +345,6 @@ static void *coex_semphr_create_wrapper(uint32_t max, uint32_t init)
 
     return NULL;
 #endif
-
 }
 
 static void coex_semphr_delete_wrapper(void *semphr)

--- a/components/esp_wifi/esp32s2/esp_adapter.c
+++ b/components/esp_wifi/esp32s2/esp_adapter.c
@@ -45,6 +45,58 @@
 
 #define TAG "esp_adapter"
 
+#if CONFIG_SPIRAM_USE_MALLOC
+/* SPIRAM Configuration */
+#define COEX_MAX_QUEUE_NUM       (2)
+
+
+/* PSRAM configuration */
+typedef struct {
+    QueueHandle_t handle;
+    void *storage;
+    void *buffer;
+} coex_queue_item_t;
+
+static DRAM_ATTR coex_queue_item_t coex_queue_table[COEX_MAX_QUEUE_NUM];
+
+static bool coex_queue_generic_register(const coex_queue_item_t *queue)
+{
+    // Coexist model will only create sempher twice in coex_pre_init when CPU start,
+    // And will never delete.
+    // So we do not need use mutex to protect it.
+
+    bool ret = false;
+    coex_queue_item_t *item;
+    for (int i = 0; i < COEX_MAX_QUEUE_NUM; ++i) {
+        item = &coex_queue_table[i];
+        if (item->handle == NULL) {
+            memcpy(item, queue, sizeof(coex_queue_item_t));
+            ret = true;
+            break;
+        }
+    }
+    assert(ret);
+    return ret;
+}
+
+static bool coex_queue_generic_deregister(coex_queue_item_t *queue)
+{
+    bool ret = false;
+    coex_queue_item_t *item;
+    for (int i = 0; i < COEX_MAX_QUEUE_NUM; ++i) {
+        item = &coex_queue_table[i];
+        if (item->handle == queue->handle) {
+            memcpy(queue, item, sizeof(coex_queue_item_t));
+            memset(item, 0, sizeof(coex_queue_item_t));
+            ret = true;
+            break;
+        }
+    }
+    return ret;
+}
+#endif
+
+
 #ifdef CONFIG_PM_ENABLE
 extern void wifi_apb80m_request(void);
 extern void wifi_apb80m_release(void);
@@ -234,6 +286,70 @@ static void * semphr_create_wrapper(uint32_t max, uint32_t init)
 static void semphr_delete_wrapper(void *semphr)
 {
     vSemaphoreDelete(semphr);
+}
+
+static void *coex_semphr_create_wrapper(uint32_t max, uint32_t init)
+{
+    void *handle = NULL;
+
+#if !CONFIG_SPIRAM_USE_MALLOC
+    handle = (void *)xSemaphoreCreateCounting(max, init);
+#else
+    StaticQueue_t *queue_buffer = NULL;
+
+    queue_buffer = heap_caps_malloc(sizeof(StaticQueue_t), MALLOC_CAP_INTERNAL|MALLOC_CAP_8BIT);
+    if (!queue_buffer) {
+        goto error;
+    }
+
+    handle = (void *)xSemaphoreCreateCountingStatic(max, init, queue_buffer);
+    if (!handle) {
+        goto error;
+    }
+
+    coex_queue_item_t item = {
+        .handle = handle,
+        .storage = NULL,
+        .buffer = queue_buffer,
+    };
+
+    if (!coex_queue_generic_register(&item)) {
+        goto error;
+    }
+#endif
+
+    return handle;
+
+#if CONFIG_SPIRAM_USE_MALLOC
+ error:
+    if (handle) {
+        vSemaphoreDelete(handle);
+    }
+    if (queue_buffer) {
+        free(queue_buffer);
+    }
+
+    return NULL;
+#endif
+
+}
+
+static void coex_semphr_delete_wrapper(void *semphr)
+{
+#if !CONFIG_SPIRAM_USE_MALLOC
+    vSemaphoreDelete(semphr);
+#else
+    coex_queue_item_t item = {
+        .handle = semphr,
+        .storage = NULL,
+        .buffer = NULL,
+    };
+
+    if (coex_queue_generic_deregister(&item)) {
+        vSemaphoreDelete(item.handle);
+        free(item.buffer);
+    }
+#endif
 }
 
 static void wifi_thread_semphr_free(void* data)
@@ -778,8 +894,8 @@ wifi_osi_funcs_t g_wifi_osi_funcs = {
 coex_adapter_funcs_t g_coex_adapter_funcs = {
     ._version = COEX_ADAPTER_VERSION,
     ._task_yield_from_isr = task_yield_from_isr_wrapper,
-    ._semphr_create = semphr_create_wrapper,
-    ._semphr_delete = semphr_delete_wrapper,
+    ._semphr_create = coex_semphr_create_wrapper,
+    ._semphr_delete = coex_semphr_delete_wrapper,
     ._semphr_take_from_isr = semphr_take_from_isr_wrapper,
     ._semphr_give_from_isr = semphr_give_from_isr_wrapper,
     ._semphr_take = semphr_take_wrapper,

--- a/components/esp_wifi/esp32s2/esp_adapter.c
+++ b/components/esp_wifi/esp32s2/esp_adapter.c
@@ -95,7 +95,6 @@ static bool coex_queue_generic_deregister(coex_queue_item_t *queue)
 }
 #endif
 
-
 #ifdef CONFIG_PM_ENABLE
 extern void wifi_apb80m_request(void);
 extern void wifi_apb80m_release(void);

--- a/components/esp_wifi/esp32s2/esp_adapter.c
+++ b/components/esp_wifi/esp32s2/esp_adapter.c
@@ -49,7 +49,6 @@
 /* SPIRAM Configuration */
 #define COEX_MAX_QUEUE_NUM       (2)
 
-
 /* PSRAM configuration */
 typedef struct {
     QueueHandle_t handle;
@@ -317,7 +316,6 @@ static void *coex_semphr_create_wrapper(uint32_t max, uint32_t init)
         goto error;
     }
 #endif
-
     return handle;
 
 #if CONFIG_SPIRAM_USE_MALLOC
@@ -331,7 +329,6 @@ static void *coex_semphr_create_wrapper(uint32_t max, uint32_t init)
 
     return NULL;
 #endif
-
 }
 
 static void coex_semphr_delete_wrapper(void *semphr)

--- a/components/esp_wifi/esp32s3/esp_adapter.c
+++ b/components/esp_wifi/esp32s3/esp_adapter.c
@@ -57,7 +57,6 @@
 /* SPIRAM Configuration */
 #define COEX_MAX_QUEUE_NUM       (2)
 
-
 /* PSRAM configuration */
 typedef struct {
     QueueHandle_t handle;
@@ -165,7 +164,6 @@ wifi_static_queue_t* wifi_create_queue( int queue_len, int item_size)
     }
 
 #if CONFIG_SPIRAM_USE_MALLOC
-
     queue->storage = heap_caps_calloc(1, sizeof(StaticQueue_t) + (queue_len*item_size), MALLOC_CAP_INTERNAL|MALLOC_CAP_8BIT);
     if (!queue->storage) {
         goto _error;
@@ -205,7 +203,6 @@ void wifi_delete_queue(wifi_static_queue_t *queue)
             free(queue->storage);
         }
 #endif
-
         free(queue);
     }
 }
@@ -325,7 +322,6 @@ static void *coex_semphr_create_wrapper(uint32_t max, uint32_t init)
         goto error;
     }
 #endif
-
     return handle;
 
 #if CONFIG_SPIRAM_USE_MALLOC
@@ -359,7 +355,6 @@ static void coex_semphr_delete_wrapper(void *semphr)
     }
 #endif
 }
-
 
 static void wifi_thread_semphr_free(void* data)
 {

--- a/components/esp_wifi/esp32s3/esp_adapter.c
+++ b/components/esp_wifi/esp32s3/esp_adapter.c
@@ -103,7 +103,6 @@ static bool coex_queue_generic_deregister(coex_queue_item_t *queue)
 }
 #endif
 
-
 #ifdef CONFIG_PM_ENABLE
 extern void wifi_apb80m_request(void);
 extern void wifi_apb80m_release(void);
@@ -335,7 +334,6 @@ static void *coex_semphr_create_wrapper(uint32_t max, uint32_t init)
 
     return NULL;
 #endif
-
 }
 
 static void coex_semphr_delete_wrapper(void *semphr)

--- a/components/esp_wifi/esp32s3/esp_adapter.c
+++ b/components/esp_wifi/esp32s3/esp_adapter.c
@@ -53,6 +53,58 @@
 
 #define TAG "esp_adapter"
 
+#if CONFIG_SPIRAM_USE_MALLOC
+/* SPIRAM Configuration */
+#define COEX_MAX_QUEUE_NUM       (2)
+
+
+/* PSRAM configuration */
+typedef struct {
+    QueueHandle_t handle;
+    void *storage;
+    void *buffer;
+} coex_queue_item_t;
+
+static DRAM_ATTR coex_queue_item_t coex_queue_table[COEX_MAX_QUEUE_NUM];
+
+static bool coex_queue_generic_register(const coex_queue_item_t *queue)
+{
+    // Coexist model will only create sempher twice in coex_pre_init when CPU start,
+    // And will never delete.
+    // So we do not need use mutex to protect it.
+
+    bool ret = false;
+    coex_queue_item_t *item;
+    for (int i = 0; i < COEX_MAX_QUEUE_NUM; ++i) {
+        item = &coex_queue_table[i];
+        if (item->handle == NULL) {
+            memcpy(item, queue, sizeof(coex_queue_item_t));
+            ret = true;
+            break;
+        }
+    }
+    assert(ret);
+    return ret;
+}
+
+static bool coex_queue_generic_deregister(coex_queue_item_t *queue)
+{
+    bool ret = false;
+    coex_queue_item_t *item;
+    for (int i = 0; i < COEX_MAX_QUEUE_NUM; ++i) {
+        item = &coex_queue_table[i];
+        if (item->handle == queue->handle) {
+            memcpy(queue, item, sizeof(coex_queue_item_t));
+            memset(item, 0, sizeof(coex_queue_item_t));
+            ret = true;
+            break;
+        }
+    }
+    return ret;
+}
+#endif
+
+
 #ifdef CONFIG_PM_ENABLE
 extern void wifi_apb80m_request(void);
 extern void wifi_apb80m_release(void);
@@ -243,6 +295,71 @@ static void semphr_delete_wrapper(void *semphr)
 {
     vSemaphoreDelete(semphr);
 }
+
+static void *coex_semphr_create_wrapper(uint32_t max, uint32_t init)
+{
+    void *handle = NULL;
+
+#if !CONFIG_SPIRAM_USE_MALLOC
+    handle = (void *)xSemaphoreCreateCounting(max, init);
+#else
+    StaticQueue_t *queue_buffer = NULL;
+
+    queue_buffer = heap_caps_malloc(sizeof(StaticQueue_t), MALLOC_CAP_INTERNAL|MALLOC_CAP_8BIT);
+    if (!queue_buffer) {
+        goto error;
+    }
+
+    handle = (void *)xSemaphoreCreateCountingStatic(max, init, queue_buffer);
+    if (!handle) {
+        goto error;
+    }
+
+    coex_queue_item_t item = {
+        .handle = handle,
+        .storage = NULL,
+        .buffer = queue_buffer,
+    };
+
+    if (!coex_queue_generic_register(&item)) {
+        goto error;
+    }
+#endif
+
+    return handle;
+
+#if CONFIG_SPIRAM_USE_MALLOC
+ error:
+    if (handle) {
+        vSemaphoreDelete(handle);
+    }
+    if (queue_buffer) {
+        free(queue_buffer);
+    }
+
+    return NULL;
+#endif
+
+}
+
+static void coex_semphr_delete_wrapper(void *semphr)
+{
+#if !CONFIG_SPIRAM_USE_MALLOC
+    vSemaphoreDelete(semphr);
+#else
+    coex_queue_item_t item = {
+        .handle = semphr,
+        .storage = NULL,
+        .buffer = NULL,
+    };
+
+    if (coex_queue_generic_deregister(&item)) {
+        vSemaphoreDelete(item.handle);
+        free(item.buffer);
+    }
+#endif
+}
+
 
 static void wifi_thread_semphr_free(void* data)
 {
@@ -803,8 +920,8 @@ wifi_osi_funcs_t g_wifi_osi_funcs = {
 coex_adapter_funcs_t g_coex_adapter_funcs = {
     ._version = COEX_ADAPTER_VERSION,
     ._task_yield_from_isr = task_yield_from_isr_wrapper,
-    ._semphr_create = semphr_create_wrapper,
-    ._semphr_delete = semphr_delete_wrapper,
+    ._semphr_create = coex_semphr_create_wrapper,
+    ._semphr_delete = coex_semphr_delete_wrapper,
     ._semphr_take_from_isr = semphr_take_from_isr_wrapper,
     ._semphr_give_from_isr = semphr_give_from_isr_wrapper,
     ._semphr_take = semphr_take_wrapper,


### PR DESCRIPTION
Apply patch to fix cache panic that occurs during Espressif Wifi Provisioning. The panic occurs because an interrupt is accessing data in spiram while spiram is off limits because of an nvs write resulting in a "Cache disabled but cached memory region accessed". 
The bandaid fix is to lower CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL to force the BT data into DRAM/IRAM with the side effect of unwanted data being moved to DRAM/IRAM. This patch forces only BT interrupt data (queue,semaphore, ect) to stay local.

Applied patch found here, https://github.com/espressif/esp-idf/issues/9129#issuecomment-1181280168 .

This is fixed on esp-idf v5.0.

