### PR TITLE
Update esp-idf for the WICED port

### DIFF
--- a/.github/workflows/pre_commit_check.yml
+++ b/.github/workflows/pre_commit_check.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python environment
         uses: actions/setup-python@master
         with:
-          python-version: v3.7
+          python-version: v3.11
       - name: Install python packages
         run: |
           pip install pre-commit

--- a/.github/workflows/pre_commit_check.yml
+++ b/.github/workflows/pre_commit_check.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python environment
         uses: actions/setup-python@master
         with:
-          python-version: v3.10
+          python-version: v3.8
       - name: Install python packages
         run: |
           pip install pre-commit

--- a/.github/workflows/pre_commit_check.yml
+++ b/.github/workflows/pre_commit_check.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python environment
         uses: actions/setup-python@master
         with:
-          python-version: v3.11
+          python-version: v3.10
       - name: Install python packages
         run: |
           pip install pre-commit

--- a/components/freertos/CMakeLists.txt
+++ b/components/freertos/CMakeLists.txt
@@ -82,6 +82,7 @@ else()
 
         set(include_dirs
             FreeRTOS-Kernel/include
+            FreeRTOS-Kernel/include/freertos
             esp_additions/include/freertos          # For files with #include "FreeRTOSConfig.h"
             FreeRTOS-Kernel/portable/xtensa/include # For arch-specific FreeRTOSConfig_arch.h in portable/<arch>/include
             esp_additions/include)                  # For files with #include "freertos/FreeRTOSConfig.h"

--- a/components/json/json.mk
+++ b/components/json/json.mk
@@ -1,0 +1,38 @@
+#
+# Copyright 2020, Cypress Semiconductor Corporation or a subsidiary of 
+ # Cypress Semiconductor Corporation. All Rights Reserved.
+ # This software, including source code, documentation and related
+ # materials ("Software"), is owned by Cypress Semiconductor Corporation
+ # or one of its subsidiaries ("Cypress") and is protected by and subject to
+ # worldwide patent protection (United States and foreign),
+ # United States copyright laws and international treaty provisions.
+ # Therefore, you may use this Software only as provided in the license
+ # agreement accompanying the software package from which you
+ # obtained this Software ("EULA").
+ # If no EULA applies, Cypress hereby grants you a personal, non-exclusive,
+ # non-transferable license to copy, modify, and compile the Software
+ # source code solely for use in connection with Cypress's
+ # integrated circuit products. Any reproduction, modification, translation,
+ # compilation, or representation of this Software except as specified
+ # above is prohibited without the express written permission of Cypress.
+ #
+ # Disclaimer: THIS SOFTWARE IS PROVIDED AS-IS, WITH NO WARRANTY OF ANY KIND,
+ # EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, NONINFRINGEMENT, IMPLIED
+ # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. Cypress
+ # reserves the right to make changes to the Software without notice. Cypress
+ # does not assume any liability arising out of the application or use of the
+ # Software or any product or circuit described in the Software. Cypress does
+ # not authorize its products for use in any products where a malfunction or
+ # failure of the Cypress product may reasonably be expected to result in
+ # significant property damage, injury or death ("High Risk Product"). By
+ # including Cypress's product in a High Risk Product, the manufacturer
+ # of such system or application assumes all risk of such use and in doing
+ # so agrees to indemnify Cypress against all liability.
+#
+
+NAME := Lib_Json
+
+GLOBAL_INCLUDES := ./cJSON
+
+$(NAME)_SOURCES := cJSON/cJSON.c \
+                   cJSON/cJSON_Utils.c

--- a/components/json/json.mk
+++ b/components/json/json.mk
@@ -1,5 +1,5 @@
 #
-# Copyright 2020, Cypress Semiconductor Corporation or a subsidiary of 
+# Copyright 2020, Cypress Semiconductor Corporation or a subsidiary of
  # Cypress Semiconductor Corporation. All Rights Reserved.
  # This software, including source code, documentation and related
  # materials ("Software"), is owned by Cypress Semiconductor Corporation


### PR DESCRIPTION
The changes here enable WICED make builds of the cJSON and freeRTOS components. They have no impact on normal esp-idf builds.